### PR TITLE
Support custom Ridley connection options

### DIFF
--- a/lib/chef-browser/app.rb
+++ b/lib/chef-browser/app.rb
@@ -18,10 +18,7 @@ module ChefBrowser
              end
 
     def chef_server
-      @chef_server ||= Ridley.new(
-        server_url: settings.rb.server_url,
-        client_name: settings.rb.client_name,
-        client_key: settings.rb.client_key)
+      @chef_server ||= settings.rb.ridley
     end
 
     get '/' do

--- a/lib/chef-browser/settings.rb
+++ b/lib/chef-browser/settings.rb
@@ -1,3 +1,4 @@
+require 'ridley'
 require 'tinyconfig'
 
 module ChefBrowser
@@ -6,5 +7,15 @@ module ChefBrowser
     option :server_url, 'https://127.0.0.1'
     option :client_name, 'chef-webui'
     option :client_key, '/etc/chef-server/chef-webui.pem'
+    option :connection, {}
+
+    # Returns a new Ridley connection, as configured by user
+    def ridley
+      ::Ridley.new({
+          server_url: server_url,
+          client_name: client_name,
+          client_key: client_key
+        }.merge(connection))
+    end
   end
 end


### PR DESCRIPTION
This commit moves creating Ridley connection to settings.py, to use the options near their definition. It also supports custom connection options, to enable connecting to a Chef server with a self-signed https certificate.
