### PR TITLE
Fix node detail view

### DIFF
--- a/lib/chef-browser/app.rb
+++ b/lib/chef-browser/app.rb
@@ -36,11 +36,11 @@ module ChefBrowser
     end
 
     get '/node/:node_name' do
+      node = chef_server.node.find(params[:node_name])
       erb :node, locals: {
-        nodes: chef_server.node.all,
-        node_name: request.path.gsub("/node/", "")
+        node: node,
+        attributes: node.chef_attributes
       }
     end
-
   end
 end

--- a/views/node.erb
+++ b/views/node.erb
@@ -1,14 +1,24 @@
-<h3><%= chef_server.node.find(node_name)[:name] %></h3>
-<p><%= chef_server.node.find(node_name)[:automatic][:fqdn] %> (<%= chef_server.node.find(node_name)[:automatic][:ipaddress] %>)</p>
-<p><strong>Environment:</strong> <%= chef_server.node.find(node_name)[:chef_environment] %></p>
-<p><strong>Tags:</strong><ul class="inline"><% chef_server.node.find(node_name)[:normal][:tags].each do |tag| %>
-<li><%= tag %></li>
+<h3><%= node.name %></h3>
+
+<p><%= node[:automatic][:fqdn] %> (<%= node[:automatic][:ipaddress] %>)</p>
+
+<p><strong>Environment:</strong> <%= node.chef_environment %></p>
+
+<p><strong>Tags:</strong>
+  <ul class="inline">
+<% (attributes[:tags] || []).each do |tag| %>
+    <li><%= tag %></li>
 <% end -%>
-</ul></p>
+  </ul>
+</p>
+
 <p><strong>Run list:</strong>
-<ul><% chef_server.node.find(node_name)[:run_list].each do |run_list| %>
-<li><%= run_list %></li>
+  <ul class="inline">
+<% node[:run_list].each do |run_list_item| %>
+    <li><%= run_list_item %></li>
 <% end -%>
-</ul></p>
+  </ul>
+</p>
+
 <h4>Attributes (JSON)</h4>
-<pre class="pre-scrollable"><%= JSON.pretty_generate(chef_server.node.find(node_name)._attributes_, :indent => "  ", :array_nl => "\n") %></pre>
+<pre class="pre-scrollable"><%= JSON.pretty_generate(node._attributes_, :indent => "  ", :array_nl => "\n") %></pre>


### PR DESCRIPTION
- Use `parameter[:node_name]` extracted for us from the URL by Sinatra instead of gsubbing it ourselves
- Get node from Chef server only once
- Don't get from Chef server list of nodes that we don't need
- Use cached merged attributes, to avoid merging them multiple times (this is kind of broken in Ridley)
- format HTML
- Element of run list is not a run list, rename it to run_list_item
- Don't explode if the node doesn't have tags
- Use merged attributes for list of tags
