### PR TITLE
Turns roles in run_list to links

### DIFF
--- a/features/node.feature
+++ b/features/node.feature
@@ -10,7 +10,11 @@ Background:
               "fqdn": "some-node-name.example.com",
               "ipaddress": "1.2.3.4",
               "records": ["Manufacturer", "Version"]
-            }
+            },
+            "run_list": [
+              "role[a-role]",
+              "recipe[a-recipe]"
+            ]
           },
           "another-node-name": {
             "automatic": {
@@ -37,3 +41,10 @@ Scenario: No attributes of some class
   When I visit "/node/some-node-name"
   And I click on "Override"
   Then I can see "This node has no override attributes."
+
+Scenario: Linking to roles
+  When I visit "/node/some-node-name"
+  Then I can see "recipe[a-recipe]"
+  And I can see "role[a-role]"
+  And I click on "role[a-role]"
+  Then I am at "/role/a-role"

--- a/views/node.erb
+++ b/views/node.erb
@@ -19,7 +19,7 @@
 <p><strong>Run list:</strong></p>
 <ul class="list-inline">
 <%   node[:run_list].each do |run_list_item| -%>
-  <li><%= run_list_item %></li>
+  <li><%== run_list_item["role"] != nil ? "<a href='" + url("/role/#{run_list_item.gsub('role[', '').chop}") + "'>#{run_list_item}</a>" : run_list_item %></li>
 <%   end -%>
 </ul>
 <% end -%>


### PR DESCRIPTION
A small improvement. In the node detail view, `role[wordpress]` will link to `role/wordpress`
