### PR TITLE
Filter input box doesn't overlay the attribute tabs on smaller screens

### DIFF
--- a/public/css/chef-browser.css
+++ b/public/css/chef-browser.css
@@ -25,6 +25,11 @@
     }
 }
 
+@media (max-width: 768px) {
+    .filter-table {
+      position: static;
+    }
+}
 footer {
     border-top: 1px solid #e5e5e5;
     background-color: #f5f5f5;


### PR DESCRIPTION
Fixes the view of resource attributes when the screen/browser window is smaller.