### PR TITLE
Fix SSL issue for cookbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##1.1.1, 2015-02-05
+
+* [bugfix] Links to individual recipes listed in a run list are no longer broken
+
 ##1.1.0, 2014-10-15
 
 * Adds a cookbook feature:

--- a/lib/chef-browser/app.rb
+++ b/lib/chef-browser/app.rb
@@ -182,7 +182,7 @@ module ChefBrowser
 
     # download a cookbook file
     get '/download/cookbook/:cookbook/*' do
-      from_server = open(cookbook_file.url)
+      from_server = open(cookbook_file.url, uri_options)
 
       # Set content_type first, so we can default to
       # 'application/octet-stream', and `attachment` doesn't blow up
@@ -200,7 +200,7 @@ module ChefBrowser
     # cookbook files
     get '/cookbook/:cookbook/*' do
       erb :file, locals: {
-        content: FileContent.show_file(cookbook_file)
+        content: FileContent.show_file(cookbook_file, uri_options)
       }
     end
 

--- a/lib/chef-browser/file_content.rb
+++ b/lib/chef-browser/file_content.rb
@@ -16,8 +16,8 @@ module ChefBrowser
     end
 
     class << self
-      def show_file(file)
-        content = FileContent.new(file.name, file.url, open(file.url).read)
+      def show_file(file, uri_options = {})
+        content = FileContent.new(file.name, file.url, open(file.url, uri_options).read)
         extname = File.extname(file.name).downcase
         if extname == '.md' || @markup_files.include?(file[:name].downcase)
           GitHub::Markup.render('README.md', content.data)

--- a/lib/chef-browser/helpers.rb
+++ b/lib/chef-browser/helpers.rb
@@ -17,6 +17,18 @@ module ChefBrowser
       session[:authorized] = false
     end
 
+    def verify_none?
+      settings.rb.connection[:ssl] && settings.rb.connection[:ssl][:verify] == false
+    end
+
+    def uri_options
+      if verify_none?
+        { ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE }
+      else
+        {}
+      end
+    end
+
     # This method takes any nested hash/array `obj`, and then
     # calls provided block with two arguments:
     # each value's jsonpath selector, and the value itself.

--- a/lib/chef-browser/helpers.rb
+++ b/lib/chef-browser/helpers.rb
@@ -164,7 +164,7 @@ module ChefBrowser
         recipe = Regexp.last_match[2]
         version = (chef_server.cookbook.all[name].first unless chef_server.cookbook.all[name].nil?) || nil
         if version
-          "<a href='#{url("/cookbook/#{name}-#{version}/recipe/#{recipe || 'default'}.rb")}'>#{run_list_element}</a>"
+          "<a href='#{url("/cookbook/#{name}-#{version}/recipes/#{recipe || 'default'}.rb")}'>#{run_list_element}</a>"
         else
           "<a href='#{url("/cookbooks")}'>#{run_list_element}</a>"
         end

--- a/lib/chef-browser/version.rb
+++ b/lib/chef-browser/version.rb
@@ -1,3 +1,3 @@
 module ChefBrowser
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
People running Chef servers with self-signed SSL certificates currently can't use chef-browser to see or download cookbooks.

If you turn off SSL verification for Ridley, it should also be turned it off for all requests to the Chef server, in this case by OpenURI.

Replaces #53 
