### PR TITLE
Adding packaging build for RPM's

### DIFF
--- a/packaging/rpm/.gitignore
+++ b/packaging/rpm/.gitignore
@@ -1,0 +1,4 @@
+.vagrant
+build
+chef-browser-checkout
+*.rpm

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -1,0 +1,63 @@
+#
+# This makefile is inspired by the fpm_with_system_ruby from:
+# https://github.com/jordansissel/fpm
+#
+# Usage:
+# VERSION variable is expected by this configuration
+# > VERSION=1.1.1 make package
+#
+
+# where to get the source
+GIT_URL=https://github.com/3ofcoins/chef-browser.git
+TAG_SPEC=refs/tags/$(VERSION)
+
+CHECKOUT_DIR=chef-browser-checkout
+BUILD_DIR=build
+LIB_DIR=$(BUILD_DIR)/opt/chef-browser
+BIN_DIR=$(BUILD_DIR)/opt/bin
+GEM_PATH:=$(shell readlink -f .)/build/gem
+CHEF_BROWSER_BIN=$(BIN_DIR)/chef-browser
+RUBY_CMD=/usr/bin/ruby
+BUNDLE_BIN=$(GEM_PATH)/bin/bundle
+BUNDLE_CMD=$(RUBY_CMD) $(BUNDLE_BIN)
+FPM_CMD=/opt/bin/fpm
+GEM_CMD=$(RUBY_CMD) -S gem
+
+.PHONY: clean
+clean:
+	rm -rf $(CHECKOUT_DIR)
+	rm -rf $(BUILD_DIR)
+	rm -f chef-browser*.rpm
+
+$(CHECKOUT_DIR):
+	rm -rf $(CHECKOUT_DIR)
+	git clone $(GIT_URL) $(CHECKOUT_DIR) --depth 1
+	cd $(CHECKOUT_DIR) && git fetch && git checkout $(TAG_SPEC)
+
+$(BUNDLE_BIN):
+	$(GEM_CMD) install bundler --install-dir=$(GEM_PATH) --no-ri --no-rdoc
+
+$(CHEF_BROWSER_BIN):
+	mkdir --parents $(BIN_DIR)
+# 	Couldn't think of a nice way to do this, so here is this code turd
+	cp bin/chef-browser $(CHEF_BROWSER_BIN)
+	chmod +x $(CHEF_BROWSER_BIN)
+
+.PHONY: install
+install: $(CHECKOUT_DIR) $(BUNDLE_BIN) $(CHEF_BROWSER_BIN)
+	mkdir --parents $(LIB_DIR)
+	cd $(CHECKOUT_DIR) && GEM_PATH=$(GEM_PATH) $(BUNDLE_CMD) install --without=development --standalone
+	cp -r $(CHECKOUT_DIR)/bundle $(LIB_DIR)/bundle
+	cp -r $(CHECKOUT_DIR)/lib $(LIB_DIR)/lib
+	cp -r $(CHECKOUT_DIR)/public $(LIB_DIR)/public
+	cp -r $(CHECKOUT_DIR)/views $(LIB_DIR)/views
+	cp $(CHECKOUT_DIR)/CHANGELOG.md $(LIB_DIR)/CHANGELOG.md
+	cp $(CHECKOUT_DIR)/LICENSE $(LIB_DIR)/LICENSE
+	cp $(CHECKOUT_DIR)/README.md $(LIB_DIR)/README.md
+	cp $(CHECKOUT_DIR)/settings.rb.example $(LIB_DIR)/settings.rb.example
+	cp config/config.ru $(LIB_DIR)/config.ru
+
+.PHONY: package
+package: install
+	$(FPM_CMD) -s dir -t rpm -n chef-browser -d ruby -d libicu -d zlib -d openssl -v $(VERSION) -C $(BUILD_DIR) opt
+

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,0 +1,40 @@
+chef-browser RPM packaging
+==========================
+
+Easy packaging of chef-browser into a RPM. It handles the needed runtime dependencies and provides a simple start script and base configuration.
+
+## Usage
+
+```
+$ VERSION=1.1.1 make package
+```
+
+### Build variables
+
+|Name   |Description|
+|-------|-----------|
+|VERSION| The version of chef-browser to be packaged. This must match a valid version tag in the chef-browser repository.|
+
+## Build dependencies
+
+    ruby
+    ruby-devel
+    libicu-devel
+    zlib-devel
+    openssl-devel
+    cmake
+    fpm
+
+## Build environment
+
+The contained Vagrantfile provides a build environment with all dependencies expect `fpm` which must be installed manually.
+
+### Using the build environment
+
+```
+vagrant up
+vagrant ssh
+# Install FPM since there are no rpm's available on standard repositories.
+cd chef-browser-build
+VERSION=1.1.1 make package
+```

--- a/packaging/rpm/Vagrantfile
+++ b/packaging/rpm/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+$SCRIPT = <<EOF
+yum groupinstall -y 'Development Tools'
+yum install -y ruby ruby-devel libicu libicu-devel zlib zlib-devel openssl openssl-devel cmake
+EOF
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 8192
+    v.cpus = 2
+  end
+
+  config.vm.define "chef-browser-build" do |server|
+    server.vm.box = 'chef/centos-7.0'
+    server.vm.hostname = 'chef-browser-build'
+    server.vm.synced_folder ".", "/home/vagrant/chef-browser-build"
+    server.vm.provision "shell", inline: $SCRIPT
+  end
+end

--- a/packaging/rpm/bin/chef-browser
+++ b/packaging/rpm/bin/chef-browser
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+ARGV << File.join(File.dirname(__FILE__), '..', 'chef-browser', 'config.ru')
+ARGV << '-o'
+ARGV << '192.168.1.125'
+load File.join(File.dirname(__FILE__), '..', 'chef-browser', 'bundle', 'bundler/setup.rb')
+require "rack"
+Rack::Server.start

--- a/packaging/rpm/config/config.ru
+++ b/packaging/rpm/config/config.ru
@@ -1,0 +1,9 @@
+#require 'bundler/setup'
+
+# Insert `lib/` subdirectory in front of require path
+_lib = File.join(File.dirname(__FILE__), 'lib')
+$:.unshift(_lib) unless $:.include?(_lib)
+
+require 'chef-browser'
+
+run ChefBrowser::App.new


### PR DESCRIPTION
This adds a packaging Makefile to create a RPM of chef-browser.

It uses the system ruby package but embeds all used gems.
It enables productive installations of chef-browser without the build dependencies.
