### PR TITLE
Adds policy name in node details when available

### DIFF
--- a/features/node.feature
+++ b/features/node.feature
@@ -6,6 +6,7 @@ Background:
       {
         "nodes": {
           "some-node-name": {
+            "chef_environment": "production",
             "automatic": {
               "fqdn": "some-node-name.example.com",
               "ipaddress": "1.2.3.4",
@@ -19,12 +20,23 @@ Background:
           "another-node-name": {
             "automatic": {
               "fqdn": "another-node-name.example.com",
-              "ipaddress": "1.2.3.5"
+              "ipaddress": "1.2.3.5",
+              "policy_name": "my-policy"
             }
           }
         }
       }
     """
+
+Scenario: Show main attributes without policy
+  When I visit "/node/some-node-name"
+  Then I can't see "Policy:"
+  And I can see "Environment: production"
+
+Scenario: Show main attributes with policy
+  When I visit "/node/another-node-name"
+  Then I can see "Policy: my-policy"
+  And I can see "Environment: _default"
 
 Scenario: List of node attributes
   When I visit "/node/some-node-name"

--- a/views/node.erb
+++ b/views/node.erb
@@ -5,6 +5,9 @@
 <p><%= node[:automatic][:fqdn] %> (<%= node[:automatic][:ipaddress] %>)</p>
 
 <p><strong>Environment:</strong> <a href='<%= url "/nodes?q=chef_environment:#{node.chef_environment}" %>'><%= node.chef_environment %></a></p>
+<% if attributes[:policy_name] && !attributes[:policy_name].empty? -%>
+<p><strong>Policy:</strong> <%= attributes[:policy_name] %></p>
+<% end -%>
 
 <% if attributes[:tags] && !attributes[:tags].empty? -%>
 <p><strong>Tags:</strong></p>


### PR DESCRIPTION
For people who use policyfiles instead of roles, it would be convenient to have the policy name associated to the node directly displayed at the top of the node details.
If the node doesn't have a policy attached, the line won't be displayed.